### PR TITLE
Add option to disable LCD wifi info page

### DIFF
--- a/src/ext_def.h
+++ b/src/ext_def.h
@@ -150,6 +150,9 @@ enum LoggerEntry
 // RGB LED BAR (0x32)
 #define HAS_LEDBAR_32 0
 
+// show wifi info on LCD display
+#define SHOW_WIFI_INFO 1
+
 //default TX trasnmit power
 #define TX_OUTPUT_POWER 20.5
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -159,6 +159,7 @@ String getConfigString(boolean maskPwd = false) {
     copyToJSON_Bool(has_lcd1602_27);
     copyToJSON_Bool(has_lcd2004_27);
     copyToJSON_Bool(has_lcd2004_3f);
+    copyToJSON_Bool(show_wifi_info);
     copyToJSON_Bool(has_ledbar_32);
     copyToJSON_String(debug);
     copyToJSON_String(sending_intervall_ms);
@@ -255,6 +256,7 @@ int readAndParseConfigFile(File configFile) {
             setFromJSON(has_lcd1602_27);
             setFromJSON(has_lcd2004_27);
             setFromJSON(has_lcd2004_3f);
+            setFromJSON(show_wifi_info);
             setFromJSON(has_ledbar_32);
             setFromJSON(debug);
             setFromJSON(sending_intervall_ms);

--- a/src/lang/intl_en.h
+++ b/src/lang/intl_en.h
@@ -42,6 +42,7 @@ const char INTL_LCD1602_3F[] PROGMEM = "LCD 1602 (I2C: 0x3F)";
 const char INTL_LCD2004_27[] PROGMEM = "LCD 2004 (I2C: 0x27)";
 const char INTL_LCD2004_3F[] PROGMEM = "LCD 2004 (I2C: 0x3F)";
 const char INTL_LEDBAR_32[] PROGMEM = "RGB LED BAR (I2C: 0x32)";
+const char INTL_SHOW_WIFI_INFO[] PROGMEM = "Display WiFi connection info on LCD";
 const char INTL_DEBUG_LEVEL[] PROGMEM = "Debug&nbsp;Level";
 const char INTL_MEASUREMENT_INTERVAL[] PROGMEM = "Measuring interval";
 const char INTL_DURATION_ROUTER_MODE[] PROGMEM = "Duration router mode";

--- a/src/lang/intl_hu.h
+++ b/src/lang/intl_hu.h
@@ -46,6 +46,7 @@ const char INTL_LCD1602_3F[] PROGMEM = "LCD 1602 (I2C: 0x3F)";
 const char INTL_LCD2004_27[] PROGMEM = "LCD 2004 (I2C: 0x27)";
 const char INTL_LCD2004_3F[] PROGMEM = "LCD 2004 (I2C: 0x3F)";
 const char INTL_LEDBAR_32[] PROGMEM = "RGB LED BAR (I2C: 0x32)";
+const char INTL_SHOW_WIFI_INFO[] PROGMEM = "A Wi-Fi kapcsolat adatainak megjelenítése az LCD-n";
 const char INTL_DEBUG_LEVEL[] PROGMEM = "Debug&nbsp;Level";
 const char INTL_MEASUREMENT_INTERVAL[] PROGMEM = "Mérési intervallum";
 const char INTL_DURATION_ROUTER_MODE[] PROGMEM = "Hotspot mód időtartama";

--- a/src/lang/intl_pl.h
+++ b/src/lang/intl_pl.h
@@ -41,6 +41,7 @@ const char INTL_LCD1602_3F[] PROGMEM = "LCD 1602 (I2C: 0x3F)";
 const char INTL_LCD2004_27[] PROGMEM = "LCD 2004 (I2C: 0x27)";
 const char INTL_LCD2004_3F[] PROGMEM = "LCD 2004 (I2C: 0x3F)";
 const char INTL_LEDBAR_32[] PROGMEM = "Linijka diodowa RGB (I2C: 0x32)";
+const char INTL_SHOW_WIFI_INFO[] PROGMEM = "Pokaż status WiFi na LCD";
 const char INTL_DEBUG_LEVEL[] PROGMEM = "Poziom&nbsp;debugowania";
 const char INTL_MEASUREMENT_INTERVAL[] PROGMEM = "Czas między pomiarami (sek.)";
 const char INTL_DURATION_ROUTER_MODE[] PROGMEM = "Czas trwania w trybie routera (sek.)";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1380,7 +1380,9 @@ void display_values() {
 	if (cfg::gps_read) {
 		screens[screen_count++] = 4;
 	}
-	screens[screen_count++] = 5;	// Wifi info
+	if (cfg::show_wifi_info) {
+		screens[screen_count++] = 5;	// Wifi info
+	}
 	screens[screen_count++] = 6;	// chipID, firmware and count of measurements
 	if (cfg::has_display || cfg::has_lcd2004_27 || cfg::has_lcd2004_3f) {
 		switch (screens[next_display_count % screen_count]) {
@@ -1467,30 +1469,30 @@ void display_values() {
 // T/H: -10.0°C/100.0%
 // T/P: -10.0°C/1000hPa
 
-	switch (screens[next_display_count % screen_count]) {
-	case (1):
-		display_lines[0] = "PM2.5: " + check_display_value(pm25_value, -1, 1, 6);
-		display_lines[1] = "PM10:  " + check_display_value(pm10_value, -1, 1, 6);
-		break;
-	case (2):
-		display_lines[0] = "T: " + check_display_value(t_value, -128, 1, 6) + char(223) + "C";
-		display_lines[1] = "H: " + check_display_value(h_value, -1, 1, 6) + "%";
-		break;
-	case (3):
-		display_lines[0] = "Lat: " + check_display_value(lat_value, -200.0, 6, 11);
-		display_lines[1] = "Lon: " + check_display_value(lon_value, -200.0, 6, 11);
-		break;
-	case (4):
-		display_lines[0] = WiFi.localIP().toString();
-		display_lines[1] = WiFi.SSID();
-		break;
-	case (5):
-		display_lines[0] = "ID: " + esp_chipid();
-		display_lines[1] = "FW: " + String(SOFTWARE_VERSION);
-		break;
-	}
-
 	if (cfg::has_lcd1602_27 || cfg::has_lcd1602) {
+		switch (screens[next_display_count % screen_count]) {
+		case (1):
+			display_lines[0] = "PM2.5: " + check_display_value(pm25_value, -1, 1, 6);
+			display_lines[1] = "PM10:  " + check_display_value(pm10_value, -1, 1, 6);
+			break;
+		case (2):
+			display_lines[0] = "T: " + check_display_value(t_value, -128, 1, 6) + char(223) + "C";
+			display_lines[1] = "H: " + check_display_value(h_value, -1, 1, 6) + "%";
+			break;
+		case (3):
+			display_lines[0] = "Lat: " + check_display_value(lat_value, -200.0, 6, 11);
+			display_lines[1] = "Lon: " + check_display_value(lon_value, -200.0, 6, 11);
+			break;
+		case (4):
+			display_lines[0] = WiFi.localIP().toString();
+			display_lines[1] = WiFi.SSID();
+			break;
+		case (5):
+			display_lines[0] = "ID: " + esp_chipid();
+			display_lines[1] = "FW: " + String(SOFTWARE_VERSION);
+			break;
+		}
+
 		char_lcd->clear();
 		char_lcd->setCursor(0, 0);
 		char_lcd->print(display_lines[0]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1480,14 +1480,18 @@ void display_values() {
 			display_lines[1] = "H: " + check_display_value(h_value, -1, 1, 6) + "%";
 			break;
 		case (3):
+			display_lines[0] = "HECA T: " + check_display_value(t_hc_value, -128, 1, 6) + " °C";
+			display_lines[1] = "HECA H: " + check_display_value(h_hc_value, -1, 1, 6) + " %";
+			break;
+		case (4):
 			display_lines[0] = "Lat: " + check_display_value(lat_value, -200.0, 6, 11);
 			display_lines[1] = "Lon: " + check_display_value(lon_value, -200.0, 6, 11);
 			break;
-		case (4):
+		case (5):
 			display_lines[0] = WiFi.localIP().toString();
 			display_lines[1] = WiFi.SSID();
 			break;
-		case (5):
+		case (6):
 			display_lines[0] = "ID: " + esp_chipid();
 			display_lines[1] = "FW: " + String(SOFTWARE_VERSION);
 			break;

--- a/src/variables.h
+++ b/src/variables.h
@@ -79,6 +79,7 @@ namespace cfg {
     extern bool has_lcd1602_27;
     extern bool has_lcd2004_27;
     extern bool has_lcd2004_3f;
+    extern bool show_wifi_info;
     extern bool has_ledbar_32;
     extern float outputPower;
     extern int  debug;

--- a/src/variables_init.h
+++ b/src/variables_init.h
@@ -51,6 +51,7 @@ namespace cfg {
     bool has_lcd1602_27 = HAS_LCD1602_27;
     bool has_lcd2004_27 = HAS_LCD2004_27;
     bool has_lcd2004_3f = HAS_LCD2004_3F;
+    bool show_wifi_info = SHOW_WIFI_INFO;
     bool has_ledbar_32 = HAS_LEDBAR_32;
     float outputPower = TX_OUTPUT_POWER;
     int debug = DEBUG;

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -331,8 +331,9 @@ void webserver_config() {
         page_content += form_option("3", FPSTR(INTL_LCD2004_27), has_lcd2004_27);
         page_content += form_option("4", FPSTR(INTL_LCD2004_3F), has_lcd2004_3f);
         page_content += F("</select></br>");
+        page_content += form_checkbox("show_wifi_info", FPSTR(INTL_SHOW_WIFI_INFO), show_wifi_info);
         page_content += form_checkbox("has_ledbar_32", FPSTR(INTL_LEDBAR_32), has_ledbar_32);
-        page_content += F("</select></br></br>");
+        page_content += F("</br></br>");
 
         if (wificonfig_loop) { //outputPower should be able to change in both modes
             page_content += form_input("outputPower", FPSTR(INTL_WIFI_TX_PWR), String(outputPower), 5);
@@ -514,6 +515,7 @@ void webserver_config() {
                     break;
             }
         }
+        readBoolParam(show_wifi_info);
         readBoolParam(has_ledbar_32);
 
 #undef readCharParam
@@ -539,6 +541,7 @@ void webserver_config() {
         page_content += line_from_value(FPSTR(INTL_LCD1602_3F), String(has_lcd1602));
         page_content += line_from_value(FPSTR(INTL_LCD2004_27), String(has_lcd2004_27));
         page_content += line_from_value(FPSTR(INTL_LCD2004_3F), String(has_lcd2004_3f));
+        page_content += line_from_value(FPSTR(INTL_SHOW_WIFI_INFO), String(show_wifi_info));
         page_content += line_from_value(FPSTR(INTL_LEDBAR_32), String(has_ledbar_32));
         page_content += line_from_value(FPSTR(INTL_DEBUG_LEVEL), String(debug));
         page_content += line_from_value(FPSTR(INTL_MEASUREMENT_INTERVAL), String(sending_intervall_ms));


### PR DESCRIPTION
It is useful for public available sensors to not show wifi informations.