### PR TITLE
MQTT suport for sending data

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,8 @@ board_build.f_flash = 40000000L
 board_build.flash_mode = dio
 
 lib_deps_external =
+  https://github.com/nettigo/Adafruit_BME280_Library.git
+  ;
   nettigo/Adafruit_BME280_Library
   ;Adafruit BME280 Library@2.0.1
   Adafruit BMP085 Library@1.0.1
@@ -31,6 +33,7 @@ lib_deps_external =
   ESP8266_SSD1306@4.1.0
   OneWire@2.3.5
   AsyncPing(esp8266)@1.1.0
+  PubSubClient@~2.7
 
   DNSServer
   ESP8266HTTPClient
@@ -41,10 +44,12 @@ lib_deps_external =
   EspSoftwareSerial
   SPI
   mikalhart/TinyGPSPlus#v0.95
-  Sensirion/arduino-sps#cf56687f7a861ab1b124d0abc7a641e1b6ef6010
+  ;Sensirion/arduino-sps#cf56687f7a861ab1b124d0abc7a641e1b6ef6010
+  sensirion/sensirion-sps @ ^0.9.0
   Wire
   576@1.1.4 ;LiquidCrystal_I2C
   pilotak/ClosedCube_SHT31D_Arduino
+  closedcube/ClosedCube SHT31D @ ^1.5.1
 
 extra_scripts =
   platformio_script.py
@@ -63,6 +68,7 @@ upload_speed = 1000000 ; Don't waste your life waiting for upload! Just buy a pr
 lang = pl
 platform = ${common.platform_version}
 framework = arduino
+;upload_port = 192.168.2.232
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
 board_build.f_flash = ${common.board_build.f_flash}

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,8 +20,6 @@ board_build.f_flash = 40000000L
 board_build.flash_mode = dio
 
 lib_deps_external =
-  https://github.com/nettigo/Adafruit_BME280_Library.git
-  ;
   nettigo/Adafruit_BME280_Library
   ;Adafruit BME280 Library@2.0.1
   Adafruit BMP085 Library@1.0.1
@@ -44,12 +42,10 @@ lib_deps_external =
   EspSoftwareSerial
   SPI
   mikalhart/TinyGPSPlus#v0.95
-  ;Sensirion/arduino-sps#cf56687f7a861ab1b124d0abc7a641e1b6ef6010
-  sensirion/sensirion-sps @ ^0.9.0
+  Sensirion/arduino-sps#cf56687f7a861ab1b124d0abc7a641e1b6ef6010
   Wire
   576@1.1.4 ;LiquidCrystal_I2C
   pilotak/ClosedCube_SHT31D_Arduino
-  closedcube/ClosedCube SHT31D @ ^1.5.1
 
 extra_scripts =
   platformio_script.py
@@ -68,7 +64,6 @@ upload_speed = 1000000 ; Don't waste your life waiting for upload! Just buy a pr
 lang = pl
 platform = ${common.platform_version}
 framework = arduino
-;upload_port = 192.168.2.232
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
 board_build.f_flash = ${common.board_build.f_flash}

--- a/src/defines.h
+++ b/src/defines.h
@@ -61,6 +61,10 @@ extern String tmpl(const String& patt, const String& value);
 
 #define JSON_BUFFER_SIZE 2000
 
+#define MQTT_MAX_PACKET_SIZE 256
+//limit sensor topic prefix size to leave space for payload
+#define SENSOR_TOPIC_PREFIX_MQTT_SIZE MQTT_MAX_PACKET_SIZE-192
+
 #define msSince(timestamp_before) (act_milli - (timestamp_before))
 
 

--- a/src/ext_def.h
+++ b/src/ext_def.h
@@ -12,6 +12,10 @@
 #define WWW_PASSWORD "admin"
 #define WWW_BASICAUTH_ENABLED 0
 
+// Initial name
+
+#define INITIAL_NAME_PART "NAM-"
+
 // Sensor Wifi config (config mode)
 #define FS_SSID ""
 #define FS_PWD ""
@@ -60,6 +64,15 @@ const char URL_INFLUX[] PROGMEM = "/write?db=luftdaten";
 #define PORT_INFLUX 8086
 #define USER_INFLUX ""
 #define PWD_INFLUX ""
+
+// Definitions for MQTT
+const char HOST_MQTT[] PROGMEM = "mqtt.server";
+const char SENSORS_TOPIC_MQTT[] PROGMEM = "/write?db=luftdaten";
+#define PORT_MQTT 1883
+#define USER_MQTT ""
+#define PWD_MQTT ""
+#define CLIENT_ID_MQTT ""
+#define SENSOR_TOPIC_PREFIX_MQTT ""
 
 // define pins for I2C
 #define I2C_PIN_SCL D4

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -54,6 +54,15 @@ String Value2Json( const __FlashStringHelper * t, const String& value) {
     return s;
 }
 
+String Value2Json( const __FlashStringHelper * t, const String& value, const __FlashStringHelper * unit) {
+    String type(t);
+    String s = F("{\"value_type\":\"{t}\",\"value\":\"{v}\", \"unit\":\"{u}\"},");
+    s.replace("{t}", type);
+    s.replace("{v}", value);
+    s.replace("{u}", unit);
+    return s;
+}
+
 /*****************************************************************
  * convert string value to json string                           *
  *****************************************************************/
@@ -210,6 +219,14 @@ String getConfigString(boolean maskPwd = false) {
     copyToJSON_Int(port_influx);
     json_string += Var2Json(F("user_influx"), user_influx);
     json_string += Var2Json(F("pwd_influx"), pwd_influx);
+
+    copyToJSON_Bool(send2mqtt);
+    json_string += Var2Json(F("host_mqtt"), host_mqtt);
+    json_string += Var2Json(F("port_mqtt"), port_mqtt);
+    json_string += Var2Json(F("client_id_mqtt"), client_id_mqtt);
+    json_string += Var2Json(F("user_mqtt"), user_mqtt);
+    json_string += Var2Json(F("pwd_mqtt"), pwd_mqtt);
+    json_string += Var2Json(F("sensors_topic_mqtt"), sensors_topic_mqtt);
 #undef copyToJSON_Bool
 #undef copyToJSON_Int
 #undef Var2Json
@@ -318,6 +335,14 @@ int readAndParseConfigFile(File configFile) {
                 host_influx = F("");
                 send2influx = 0;
             }
+
+            setFromJSON(send2mqtt);
+            if (json.containsKey(F("host_mqtt"))) host_mqtt = json.get<String>(F("host_mqtt"));
+            setFromJSON(port_mqtt);
+            strcpyFromJSON(client_id_mqtt);
+            if (json.containsKey(F("user_mqtt"))) user_mqtt = json.get<String>(F("user_mqtt"));
+            if (json.containsKey(F("pwd_mqtt"))) pwd_mqtt = json.get<String>(F("pwd_mqtt"));
+            if (json.containsKey(F("sensors_topic_mqtt"))) sensors_topic_mqtt = json.get<String>(F("sensors_topic_mqtt"));
             configFile.close();
             if (pms24_read || pms32_read) {
                 pms_read = 1;

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -23,6 +23,7 @@ int readAndParseConfigFile(File);
 String add_sensor_type(const String& sensor_text);
 String Value2Json(const String& type, const String& value);
 String Value2Json(const __FlashStringHelper *, const String& value);
+String Value2Json( const __FlashStringHelper * t, const String& value, const __FlashStringHelper * unit);
 String Var2Json(const String& name, const bool value);
 String Var2JsonInt(const String& name, const bool value);
 String Var2Json(const String& name, const int value);

--- a/src/lang/intl_en.h
+++ b/src/lang/intl_en.h
@@ -32,6 +32,7 @@ Files with .lang extension are searched in following directories and it's subdir
 /* ./src/lang/intl_en.lang */ const char INTL_BME280[] PROGMEM = "BME280 ({t}, {h}, {p})";
 /* ./src/lang/intl_en.lang */ const char INTL_BMP280[] PROGMEM = "BMP280 ({t}, {p})";
 /* ./src/lang/intl_en.lang */ const char INTL_CANCEL[] PROGMEM = "Cancel";
+/* ./src/lang/intl_en.lang */ const char INTL_CLIENT_ID[] PROGMEM = "Client Id";
 /* ./src/lang/intl_en.lang */ const char INTL_CONFIGURATION[] PROGMEM = "Configuration";
 /* ./src/lang/intl_en.lang */ const char INTL_CONFIGURATION_DELETE[] PROGMEM = "Configuration delete";
 /* ./src/lang/intl_en.lang */ const char INTL_CONFIGURATION_REALLY_DELETE[] PROGMEM = "Are you sure you want to delete the configuration?";
@@ -106,6 +107,7 @@ Files with .lang extension are searched in following directories and it's subdir
 /* ./src/lang/intl_en.lang */ const char INTL_SEND_TO_OWN_API[] PROGMEM = "Send data to own API";
 /* ./src/lang/intl_en.lang */ const char INTL_SENSOR[] PROGMEM = "Sensor";
 /* ./src/lang/intl_en.lang */ const char INTL_SENSORS[] PROGMEM = "Sensors";
+/* ./src/lang/intl_en.lang */ const char INTL_SENSORS_TOPIC_MQTT[] PROGMEM = "Sensors topic prefix";
 /* ./src/lang/intl_en.lang */ const char INTL_SENSOR_IS_REBOOTING[] PROGMEM = "Sensor is rebooting.";
 /* ./src/lang/intl_en.lang */ const char INTL_SERVER[] PROGMEM = "Server";
 /* ./src/lang/intl_en.lang */ const char INTL_SHOW_WIFI_INFO[] PROGMEM = "Display WiFi connection info on LCD";

--- a/src/lang/intl_en.lang
+++ b/src/lang/intl_en.lang
@@ -49,6 +49,8 @@ INTL_PATH Path
 INTL_PORT Port
 INTL_USER User
 INTL_PASSWORD Password
+INTL_CLIENT_ID Client Id
+INTL_SENSORS_TOPIC_MQTT Sensors topic prefix
 INTL_SEND_TO Send to {v}
 INTL_READ_FROM Read from {v}
 INTL_SENSOR_IS_REBOOTING Sensor is rebooting.

--- a/src/lang/intl_hu.h
+++ b/src/lang/intl_hu.h
@@ -33,6 +33,7 @@ Files with .lang extension are searched in following directories and it's subdir
 /* ./src/lang/intl_hu.lang */ const char INTL_BMP180[] PROGMEM = "BMP180 ({t}, {p})";
 /* ./src/lang/intl_hu.lang */ const char INTL_BMP280[] PROGMEM = "BMP280 ({t}, {p})";
 /* ./src/lang/intl_hu.lang */ const char INTL_CANCEL[] PROGMEM = "Mégse";
+/* ./src/lang/intl_hu.lang */ const char INTL_CLIENT_ID[] PROGMEM = "Client Id";
 /* ./src/lang/intl_hu.lang */ const char INTL_CONFIGURATION[] PROGMEM = "Konfiguráció";
 /* ./src/lang/intl_hu.lang */ const char INTL_CONFIGURATION_DELETE[] PROGMEM = "Beállítások törlése";
 /* ./src/lang/intl_hu.lang */ const char INTL_CONFIGURATION_REALLY_DELETE[] PROGMEM = "Biztosan törölni akarod a beállításokat?";
@@ -107,6 +108,7 @@ Files with .lang extension are searched in following directories and it's subdir
 /* ./src/lang/intl_hu.lang */ const char INTL_SEND_TO_OWN_API[] PROGMEM = "Adatok küldése saját API-nak";
 /* ./src/lang/intl_hu.lang */ const char INTL_SENSOR[] PROGMEM = "Szenzor";
 /* ./src/lang/intl_hu.lang */ const char INTL_SENSORS[] PROGMEM = "Szenzorok";
+/* ./src/lang/intl_hu.lang */ const char INTL_SENSORS_TOPIC_MQTT[] PROGMEM = "Sensors topic prefix";
 /* ./src/lang/intl_hu.lang */ const char INTL_SENSOR_IS_REBOOTING[] PROGMEM = "A Szenzor újraindul...";
 /* ./src/lang/intl_hu.lang */ const char INTL_SERVER[] PROGMEM = "Szerver";
 /* ./src/lang/intl_hu.lang */ const char INTL_SHOW_WIFI_INFO[] PROGMEM = "A Wi-Fi kapcsolat adatainak megjelenítése az LCD-n";
@@ -128,9 +130,6 @@ Files with .lang extension are searched in following directories and it's subdir
 /* ./src/lang/intl_hu.lang */ const char INTL_WIFI_SETTINGS[] PROGMEM = "WiFi beállítások";
 /* ./src/lang/intl_hu.lang */ const char INTL_WIFI_TX_PWR[] PROGMEM = "TX power 0-20.5(dBm)";
 /* ./src/lang/intl_hu.lang */ const char LUFTDATEN_INFO_LOGO_SVG[] PROGMEM = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"120px\" height=\"90px\" version=\"1.0\" style=\"shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd\" viewBox=\"0 0 120 90\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><g id=\"NAM Logo\"><path fill=\"#fff\" d=\"M50 27c0,1 -1,2 -2,2 -1,0 -2,-1 -2,-2 0,-8 6,-14 14,-14 7,0 13,6 13,14 0,7 -6,13 -13,13l-32 0c-12,0 -21,10 -21,21 0,14 13,23 26,20 2,-1 3,-1 5,-2 1,-1 2,0 3,1 1,1 0,2 -1,3 -10,6 -22,4 -30,-4 -10,-10 -10,-26 0,-36 4,-4 11,-7 18,-7l32 0c8,0 12,-10 6,-16 -6,-6 -16,-1 -16,7zm5 52c0,0 -1,0 -1,0l0 0 -1 -2 -3 0c0,1 0,2 0,2 -1,0 -1,0 -2,0 0,0 0,0 0,0l3 -8c0,0 0,0 0,0l0 0c1,0 2,0 2,0l3 8c0,0 0,0 -1,0l0 0zm6 -13c0,0 0,-8 0,-10 0,-2 1,-2 1,-2l6 0 0 2 -4 0 0 3 4 0 0 2 -4 0 0 3 4 0 0 2 -7 0zm11 0l0 -10 -4 0c0,0 0,-2 2,-2l17 0 0 2 -3 0 0 10 -3 0 0 -10c-2,0 -4,0 -6,0l0 10 -3 0zm16 0c0,0 0,-8 0,-10 0,-2 3,-2 3,-2l0 12 -3 0zm22 -12c2,0 3,0 5,1 1,2 2,3 2,5 0,2 -1,4 -2,5 -2,1 -3,2 -5,2 -1,0 -3,-1 -4,-2 -2,-1 -2,-3 -2,-5 0,-2 0,-3 2,-5 1,-1 3,-1 4,-1zm0 2c-1,0 -1,0 -2,1 -1,1 -1,2 -1,3 0,2 0,3 1,3 0,1 1,2 2,2 1,0 2,-1 3,-2 0,-1 1,-2 1,-3 0,-1 -1,-2 -1,-3 -1,-1 -2,-1 -3,-1zm-62 10c0,0 0,-8 0,-10 0,-2 2,-2 2,-2l7 8c0,0 0,-4 0,-6 0,-2 2,-2 2,-2l0 12 -2 0 -7 -8 0 6 0 2 -2 0 0 0zm55 -6c0,0 -3,0 -3,0 -2,0 -2,2 -2,2l3 0c0,2 0,2 0,2 -1,0 -1,1 -2,1 -1,0 -2,-1 -3,-2 -1,0 -1,-2 -1,-3 0,-1 0,-2 1,-3 1,-1 2,-1 3,-1 1,0 2,0 3,0l1 -1c-2,-1 -3,-1 -4,-1 -1,0 -2,0 -3,0 -1,1 -2,1 -3,2 -1,1 -1,3 -1,4 0,1 0,2 0,3 1,1 1,2 2,2 2,1 3,2 5,2 1,0 3,-1 4,-1l0 -6 0 0zm-52 16l2 0 -1 -2 -1 2zm6 3c0,0 -1,0 -1,0l0 -8c0,0 1,0 1,0 1,0 1,0 1,0l0 8c0,0 0,0 -1,0zm4 -3l0 3c0,0 -1,0 -1,0 -1,0 -1,0 -1,0l0 -8c0,0 0,0 1,0 1,0 2,0 3,0 1,0 1,1 2,1l0 0c0,2 0,3 -2,4l2 3c1,0 0,0 0,0l0 0c-1,0 -1,0 -2,0l-2 -3 0 0zm0 -1c1,0 2,0 2,-1 0,-1 -1,-1 -2,-1l0 2zm11 1l3 -5c0,0 0,0 0,0l0 0c0,0 0,0 0,0l0 0 1 0c0,0 0,0 0,0l0 8c0,0 0,0 -1,0 0,0 0,0 0,0l0 -4 -2 3c0,0 -1,0 -2,0l-1 -3 0 4c0,0 -1,0 -2,0 0,0 0,0 0,0l0 -8c0,0 0,0 1,0 0,0 1,0 1,0l2 5zm13 -1c0,6 -8,6 -8,0 0,-6 8,-6 8,0zm-2 0c0,-1 0,-1 0,-2l0 0c-1,-1 -2,-1 -3,0l0 0c-2,1 -1,5 2,5 1,-1 1,-2 1,-3zm4 -4c0,0 0,0 0,0l4 5 0 -5c0,0 1,0 1,0 0,0 1,0 1,0l0 8c0,1 -1,0 -2,0l0 0 0 0 -3 -5 0 5c0,0 -1,0 -2,0 0,0 0,0 0,0l0 -8c0,0 0,0 1,0zm8 8c0,0 -1,0 -1,0l0 -8c0,0 1,0 1,0 1,0 1,0 1,0l0 8c0,0 0,0 -1,0zm8 -8c0,2 0,2 -3,2l0 6c0,0 0,0 -1,0 0,0 -1,0 -1,0l0 -6c-2,0 -2,0 -2,-2 0,0 0,0 1,0l5 0c1,0 1,0 1,0zm7 4c0,6 -8,6 -8,0 0,-6 8,-6 8,0zm-2 0c0,-1 0,-1 0,-2l0 0c-1,-1 -2,-1 -3,0l0 0c-2,1 -1,5 2,5 1,-1 1,-2 1,-3zm5 1l0 3c0,0 -1,0 -2,0 0,0 0,0 0,0l0 -8c0,0 0,0 0,0 1,0 3,0 4,0 2,1 2,4 0,5l2 3c1,0 0,0 0,0l0 0c-1,0 -1,0 -2,0l-2 -3 0 0zm0 -1c1,0 2,0 2,-1 0,-1 -1,-1 -2,-1l0 2zm-85 -18c-3,0 -6,2 -7,4 1,2 4,4 7,4 3,0 5,-2 7,-4 -2,-2 -4,-4 -7,-4zm0 2c1,0 2,1 2,2 0,1 -1,2 -2,2 -2,0 -3,-1 -3,-2 0,-1 1,-2 3,-2zm22 -48c-1,0 -2,0 -3,-1 0,-1 0,-2 1,-3 9,-5 20,-4 28,4 9,8 9,23 0,32 -4,4 -10,7 -16,7l-32 0c-7,0 -12,5 -12,11 0,6 5,11 12,11 7,0 13,-7 11,-14 -1,-1 0,-2 1,-3 2,0 3,1 3,2 3,10 -5,20 -15,20 -9,0 -16,-7 -16,-16 0,-9 7,-16 16,-16l32 0c10,0 18,-8 18,-18 0,-12 -12,-21 -23,-18 -2,0 -3,1 -5,2z\"/></g></svg>";
- const char INTL_NTW_WTD_DESC[] PROGMEM = "Translate HU: INTL_NTW_WTD_DESC 🐱;";
- const char INTL_NTW_WTD_HOST[] PROGMEM = "Translate HU: INTL_NTW_WTD_HOST 🐱;";
- const char INTL_NTW_WTD_ERROR[] PROGMEM = "Translate HU: INTL_NTW_WTD_ERROR 🐱;";
  const char INTL_SPS30_CONCENTRATION[] PROGMEM = "Translate HU: INTL_SPS30_CONCENTRATION 🐱;";
  const char INTL_SPS30_SIZE[] PROGMEM = "Translate HU: INTL_SPS30_SIZE 🐱;";
  const char INTL_SPS30_NO_RESULT[] PROGMEM = "Translate HU: INTL_SPS30_NO_RESULT 🐱;";
@@ -138,6 +137,9 @@ Files with .lang extension are searched in following directories and it's subdir
  const char INTL_SPS30_COUNTS[] PROGMEM = "Translate HU: INTL_SPS30_COUNTS 🐱;";
  const char INTL_SPS30_SENSOR_DESC[] PROGMEM = "Translate HU: INTL_SPS30_SENSOR_DESC 🐱;";
  const char INTL_SPS30_REFRESH[] PROGMEM = "Translate HU: INTL_SPS30_REFRESH 🐱;";
+ const char INTL_NTW_WTD_DESC[] PROGMEM = "Translate HU: INTL_NTW_WTD_DESC 🐱;";
+ const char INTL_NTW_WTD_HOST[] PROGMEM = "Translate HU: INTL_NTW_WTD_HOST 🐱;";
+ const char INTL_NTW_WTD_ERROR[] PROGMEM = "Translate HU: INTL_NTW_WTD_ERROR 🐱;";
  const char INTL_UPDATE_ALFA[] PROGMEM = "Translate HU: INTL_UPDATE_ALFA 🐱;";
  const char INTL_UPDATE_BETA[] PROGMEM = "Translate HU: INTL_UPDATE_BETA 🐱;";
  const char INTL_UPDATE_STABLE[] PROGMEM = "Translate HU: INTL_UPDATE_STABLE 🐱;";

--- a/src/lang/intl_hu.lang
+++ b/src/lang/intl_hu.lang
@@ -47,6 +47,8 @@ INTL_PATH Útvonal
 INTL_PORT Port
 INTL_USER Felhasználónév
 INTL_PASSWORD Jelszó
+INTL_CLIENT_ID Client Id
+INTL_SENSORS_TOPIC_MQTT Sensors topic prefix
 INTL_SEND_TO Send to {v}
 INTL_READ_FROM Read from {v}
 INTL_SENSOR_IS_REBOOTING A Szenzor újraindul...

--- a/src/lang/intl_pl.h
+++ b/src/lang/intl_pl.h
@@ -32,6 +32,7 @@ Files with .lang extension are searched in following directories and it's subdir
 /* ./src/lang/intl_pl.lang */ const char INTL_BME280[] PROGMEM = "BME280 ({t}, {h}, {p})";
 /* ./src/lang/intl_pl.lang */ const char INTL_BMP280[] PROGMEM = "BMP280 ({t}, {p})";
 /* ./src/lang/intl_pl.lang */ const char INTL_CANCEL[] PROGMEM = "Anuluj";
+/* ./src/lang/intl_pl.lang */ const char INTL_CLIENT_ID[] PROGMEM = "Nazwa klienta";
 /* ./src/lang/intl_pl.lang */ const char INTL_CONFIGURATION[] PROGMEM = "Konfiguracja";
 /* ./src/lang/intl_pl.lang */ const char INTL_CONFIGURATION_DELETE[] PROGMEM = "Usunięcie konfiguracji";
 /* ./src/lang/intl_pl.lang */ const char INTL_CONFIGURATION_REALLY_DELETE[] PROGMEM = "Czy na pewno chcesz usunąć konfigurację?";
@@ -67,7 +68,6 @@ Files with .lang extension are searched in following directories and it's subdir
 /* ./src/lang/intl_pl.lang */ const char INTL_LCD1602_3F[] PROGMEM = "LCD 1602 (I2C: 0x3F)";
 /* ./src/lang/intl_pl.lang */ const char INTL_LCD2004_27[] PROGMEM = "LCD 2004 (I2C: 0x27)";
 /* ./src/lang/intl_pl.lang */ const char INTL_LCD2004_3F[] PROGMEM = "LCD 2004 (I2C: 0x3F)";
-/* ./src/lang/intl_pl.lang */ const char INTL_LEDBAR_32[] PROGMEM = "Linijka diodowa RGB (I2C: 0x32)";
 /* ./src/lang/intl_pl.lang */ const char INTL_LONGITUDE[] PROGMEM = "Długość geograficzna";
 /* ./src/lang/intl_pl.lang */ const char INTL_MAX_INFO[] PROGMEM = "maks. info";
 /* ./src/lang/intl_pl.lang */ const char INTL_MEASUREMENT_INTERVAL[] PROGMEM = "Czas między pomiarami (sek.)";
@@ -106,6 +106,7 @@ Files with .lang extension are searched in following directories and it's subdir
 /* ./src/lang/intl_pl.lang */ const char INTL_SEND_TO_OWN_API[] PROGMEM = "Wysyłaj dane do własnego API";
 /* ./src/lang/intl_pl.lang */ const char INTL_SENSOR[] PROGMEM = "Czujnik";
 /* ./src/lang/intl_pl.lang */ const char INTL_SENSORS[] PROGMEM = "Sensory";
+/* ./src/lang/intl_pl.lang */ const char INTL_SENSORS_TOPIC_MQTT[] PROGMEM = "Prefiks tematu sensorów";
 /* ./src/lang/intl_pl.lang */ const char INTL_SENSOR_IS_REBOOTING[] PROGMEM = "Ponowne uruchamianie czujnika.";
 /* ./src/lang/intl_pl.lang */ const char INTL_SERVER[] PROGMEM = "Adres serwera";
 /* ./src/lang/intl_pl.lang */ const char INTL_SHOW_WIFI_INFO[] PROGMEM = "Pokaż status WiFi na LCD";
@@ -142,3 +143,4 @@ Files with .lang extension are searched in following directories and it's subdir
  const char INTL_PPD42NS[] PROGMEM = "Translate PL: INTL_PPD42NS 🐱;";
  const char INTL_HTU21D[] PROGMEM = "Translate PL: INTL_HTU21D 🐱;";
  const char INTL_BMP180[] PROGMEM = "Translate PL: INTL_BMP180 🐱;";
+ const char INTL_LEDBAR_32[] PROGMEM = "Translate PL: INTL_LEDBAR_32 🐱;";

--- a/src/lang/intl_pl.lang
+++ b/src/lang/intl_pl.lang
@@ -34,7 +34,6 @@ INTL_LCD1602_27 LCD 1602 (I2C: 0x27)
 INTL_LCD1602_3F LCD 1602 (I2C: 0x3F)
 INTL_LCD2004_27 LCD 2004 (I2C: 0x27)
 INTL_LCD2004_3F LCD 2004 (I2C: 0x3F)
-INTL_LEDBAR_32 Linijka diodowa RGB (I2C: 0x32)
 INTL_SHOW_WIFI_INFO Pokaż status WiFi na LCD
 INTL_DEBUG_LEVEL Poziom&nbsp;debugowania
 INTL_MEASUREMENT_INTERVAL Czas między pomiarami (sek.)
@@ -46,6 +45,8 @@ INTL_PATH Ścieżka
 INTL_PORT Port
 INTL_USER Nazwa użytkownika
 INTL_PASSWORD Hasło
+INTL_CLIENT_ID Nazwa klienta
+INTL_SENSORS_TOPIC_MQTT Prefiks tematu sensorów
 INTL_SEND_TO Wysyłaj dane do {v}
 INTL_READ_FROM Czytaj z {v}
 INTL_SENSOR_IS_REBOOTING Ponowne uruchamianie czujnika.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -561,7 +561,7 @@ static String sensorBMP280() {
 		last_value_BMP280_T = t;
 		last_value_BMP280_P = p;
 		s += Value2Json(F("BMP280_pressure"), Float2String(last_value_BMP280_P), F("Pa"));
-		s += Value2Json(F("BMP280_temperature"), Float2String(last_value_BMP280_T), F("C"));
+		s += Value2Json(F("BMP280_temperature"), Float2String(last_value_BMP280_T), F("°C"));
 	}
 	debug_out("----", DEBUG_MIN_INFO, 1);
 
@@ -599,7 +599,7 @@ static String sensorDS18B20() {
 		debug_out(FPSTR(DBG_TXT_TEMPERATURE), DEBUG_MIN_INFO, 0);
 		debug_out(Float2String(t) + " C", DEBUG_MIN_INFO, 1);
 		last_value_DS18B20_T = t;
-		s += Value2Json(F("DS18B20_temperature"), Float2String(last_value_DS18B20_T), F("C"));
+		s += Value2Json(F("DS18B20_temperature"), Float2String(last_value_DS18B20_T), F("°C"));
 	}
 	debug_out("----", DEBUG_MIN_INFO, 1);
 	debug_out(String(FPSTR(DBG_TXT_END_READING)) + FPSTR(SENSORS_DS18B20), DEBUG_MED_INFO, 1);
@@ -1184,8 +1184,7 @@ void setup() {
 	if (cfg::send2mqtt) {
         display_debug(F("Connecting to"), F("MQTT..."));
         mqtt::setup(wifi_client);
-        mqtt::reconnect(3);
-
+        mqtt::reconnect(2);
 	    if (!mqtt::client.connected()) {
 	        display_debug(F("Failed to connect"), F("to MQTT server"));
 	    }
@@ -1341,6 +1340,10 @@ void loop() {
 
 	server.handleClient();
 
+	if (cfg::send2mqtt) {
+	    mqtt::loop();
+	}
+
 	if (send_now) {
         debugData(String(F("****************** Upload data to APIs*****************************")));
         if (cfg::dht_read) {
@@ -1387,11 +1390,6 @@ void loop() {
 
 	if ((cfg::has_ledbar_32) && (send_now)) {
 		displayLEDBar();
-	}
-
-	if (cfg::send2mqtt) {
-	    mqtt::reconnect(1);
-	    mqtt::client.loop();
 	}
 
 	if (send_now) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,9 +32,11 @@
 #include "sensors/winsen-mhz.h"
 #include "display/commons.h"
 #include "display/ledbar.h"
+#include "mqtt.h"
 
 SimpleScheduler::NAMFScheduler scheduler;
 
+WiFiClient wifi_client;
 
 /*****************************************************************
  * send Plantower PMS sensor command start, stop, cont. mode     *
@@ -558,8 +560,8 @@ static String sensorBMP280() {
 		debug_out(Float2String(p / 100) + " hPa", DEBUG_MIN_INFO, 1);
 		last_value_BMP280_T = t;
 		last_value_BMP280_P = p;
-		s += Value2Json(F("BMP280_pressure"), Float2String(last_value_BMP280_P));
-		s += Value2Json(F("BMP280_temperature"), Float2String(last_value_BMP280_T));
+		s += Value2Json(F("BMP280_pressure"), Float2String(last_value_BMP280_P), F("Pa"));
+		s += Value2Json(F("BMP280_temperature"), Float2String(last_value_BMP280_T), F("C"));
 	}
 	debug_out("----", DEBUG_MIN_INFO, 1);
 
@@ -597,7 +599,7 @@ static String sensorDS18B20() {
 		debug_out(FPSTR(DBG_TXT_TEMPERATURE), DEBUG_MIN_INFO, 0);
 		debug_out(Float2String(t) + " C", DEBUG_MIN_INFO, 1);
 		last_value_DS18B20_T = t;
-		s += Value2Json(F("DS18B20_temperature"), Float2String(last_value_DS18B20_T));
+		s += Value2Json(F("DS18B20_temperature"), Float2String(last_value_DS18B20_T), F("C"));
 	}
 	debug_out("----", DEBUG_MIN_INFO, 1);
 	debug_out(String(FPSTR(DBG_TXT_END_READING)) + FPSTR(SENSORS_DS18B20), DEBUG_MED_INFO, 1);
@@ -1179,6 +1181,16 @@ void setup() {
         debug_out(F("\nmDNS failure!"), DEBUG_ERROR, 1);
     }
 
+	if (cfg::send2mqtt) {
+        display_debug(F("Connecting to"), F("MQTT..."));
+        mqtt::setup(wifi_client);
+        mqtt::reconnect(3);
+
+	    if (!mqtt::client.connected()) {
+	        display_debug(F("Failed to connect"), F("to MQTT server"));
+	    }
+	}
+
     delay(50);
 
 	// sometimes parallel sending data and web page will stop nodemcu, watchdogtimer set to 30 seconds
@@ -1259,6 +1271,10 @@ static unsigned long sendDataToOptionalApis(const String &data) {
 		sum_send_time += millis() - start_send;
 	}
     debugData(data,F("po custom "));
+
+	if (cfg::send2mqtt) {
+	    mqtt::send_mqtt(data);
+	}
 
     return sum_send_time;
 }
@@ -1371,6 +1387,11 @@ void loop() {
 
 	if ((cfg::has_ledbar_32) && (send_now)) {
 		displayLEDBar();
+	}
+
+	if (cfg::send2mqtt) {
+	    mqtt::reconnect(1);
+	    mqtt::client.loop();
 	}
 
 	if (send_now) {

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -1,0 +1,75 @@
+//
+// Created by Julian Szulc on 08/08/2020.
+//
+#include "mqtt.h"
+#include "helpers.h"
+#include "ext_def.h"
+#include "variables.h"
+#include <ArduinoJson.h>
+#include "html-content.h"
+
+#undef MQTT_MAX_PACKET_SIZE
+#define MQTT_MAX_PACKET_SIZE 2048
+
+namespace mqtt {
+
+    PubSubClient client;
+
+    void setup(WiFiClient &wifiClient) {
+        client.setClient(wifiClient);
+        client.setServer(cfg::host_mqtt.c_str(), cfg::port_mqtt);
+    }
+
+
+    void reconnect(int maxRetries) {
+        int retries = 0;
+        while (!(client.connected())) {
+            if (retries < maxRetries) {
+                debug_out(F("Attempting MQTT connection..."), DEBUG_MIN_INFO, false);
+                if (client.connect(cfg::client_id_mqtt, cfg::user_mqtt.c_str(), cfg::pwd_mqtt.c_str())) {
+                    debug_out(F("connected"), DEBUG_MIN_INFO, true);
+                } else {
+                    debug_out(F("failed, rc="), DEBUG_WARNING, false);
+                    debug_out(String(client.state()), DEBUG_WARNING, false);
+                    debug_out(F(" try again in 0.5 second"), DEBUG_WARNING, true);
+                    retries++;
+                    yield();
+                    delay(500);
+                }
+            } else {
+                debug_out(F("Failed to (re)connect to MQTT"), DEBUG_ERROR, true);
+                break;
+            }
+        }
+    }
+
+    void publish(const String& mqtt_topic, const String &data, bool retained = false) {
+        reconnect(3);
+        if (!client.publish(mqtt_topic.c_str(), data.c_str(), retained)) {
+            debug_out(F("Failed to publish data to mqtt:"), DEBUG_WARNING, false);
+            debug_out(data, DEBUG_WARNING, true);
+        }
+    }
+
+    void send_mqtt(const String& data) {
+        StaticJsonBuffer<JSON_BUFFER_SIZE> jsonBuffer;
+        JsonObject& json2data = jsonBuffer.parseObject(data);
+        time_t now = time(nullptr);
+        String timestamp=(ctime(&now));
+        timestamp.trim();
+        if (json2data.success()) {
+            for (uint8_t i = 0; i < json2data["sensordatavalues"].size(); i++) {
+                JsonObject& sensor_value = json2data["sensordatavalues"][i];
+                sensor_value.set(F("timestamp"), timestamp);
+                String mqtt_type = sensor_value[F("value_type")].as<String>();
+                sensor_value.remove(F("value_type"));
+                String mqtt_value;
+                sensor_value.printTo(mqtt_value);
+                mqtt::publish(cfg::sensors_topic_mqtt + mqtt_type, mqtt_value);
+            }
+            mqtt::publish(cfg::sensors_topic_mqtt + "last_data_time", String(now, 10), true);
+        } else {
+            debug_out(FPSTR(DBG_TXT_DATA_READ_FAILED), DEBUG_ERROR, true);
+        }
+    }
+}

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -15,11 +15,12 @@ namespace mqtt {
 
     PubSubClient client;
 
+    int skip_loops = 0;
+
     void setup(WiFiClient &wifiClient) {
         client.setClient(wifiClient);
         client.setServer(cfg::host_mqtt.c_str(), cfg::port_mqtt);
     }
-
 
     void reconnect(int maxRetries) {
         int retries = 0;
@@ -27,23 +28,31 @@ namespace mqtt {
             if (retries < maxRetries) {
                 debug_out(F("Attempting MQTT connection..."), DEBUG_MIN_INFO, false);
                 if (client.connect(cfg::client_id_mqtt, cfg::user_mqtt.c_str(), cfg::pwd_mqtt.c_str())) {
+                    skip_loops = 0;
                     debug_out(F("connected"), DEBUG_MIN_INFO, true);
                 } else {
+                    int connection_state = client.state();
                     debug_out(F("failed, rc="), DEBUG_WARNING, false);
-                    debug_out(String(client.state()), DEBUG_WARNING, false);
-                    debug_out(F(" try again in 0.5 second"), DEBUG_WARNING, true);
+                    debug_out(String(connection_state), DEBUG_WARNING, false);
+                    if (connection_state == MQTT_CONNECT_UNAUTHORIZED || connection_state == MQTT_CONNECT_BAD_CREDENTIALS) {
+                        debug_out(F(" invalid authentication data"), DEBUG_WARNING, true);
+                        skip_loops = 1024;
+                        return;
+                    }
+                    debug_out(F(" will try again in 0.33 seconds"), DEBUG_WARNING, true);
                     retries++;
+                    delay(330);
                     yield();
-                    delay(500);
                 }
             } else {
                 debug_out(F("Failed to (re)connect to MQTT"), DEBUG_ERROR, true);
-                break;
+                return;
             }
         }
     }
 
     void publish(const String& mqtt_topic, const String &data, bool retained = false) {
+        debug_out(F("MQTT publish"), DEBUG_MIN_INFO, true);
         reconnect(3);
         if (!client.publish(mqtt_topic.c_str(), data.c_str(), retained)) {
             debug_out(F("Failed to publish data to mqtt:"), DEBUG_WARNING, false);
@@ -62,14 +71,31 @@ namespace mqtt {
                 JsonObject& sensor_value = json2data["sensordatavalues"][i];
                 sensor_value.set(F("timestamp"), timestamp);
                 String mqtt_type = sensor_value[F("value_type")].as<String>();
+                if (sensor_value[F("unit")].as<String>() == F("Pa")) {
+                    sensor_value.set(F("value"), sensor_value[F("value")].as<double>()/100);
+                    sensor_value.set(F("unit"), "hPa");
+                } else {
+                    sensor_value.set(F("value"), sensor_value[F("value")].as<double>());
+                }
                 sensor_value.remove(F("value_type"));
                 String mqtt_value;
                 sensor_value.printTo(mqtt_value);
+                debug_out("mqtt data: " + mqtt_type + " ", DEBUG_MIN_INFO, false);
+                debug_out(mqtt_value, DEBUG_MIN_INFO, true);
                 mqtt::publish(cfg::sensors_topic_mqtt + mqtt_type, mqtt_value);
+                yield();
             }
-            mqtt::publish(cfg::sensors_topic_mqtt + "last_data_time", String(now, 10), true);
         } else {
             debug_out(FPSTR(DBG_TXT_DATA_READ_FAILED), DEBUG_ERROR, true);
         }
+    }
+
+    bool loop() {
+        if (skip_loops > 0) {
+            skip_loops--;
+            return false;
+        }
+        reconnect(1);
+        return client.loop();
     }
 }

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -17,6 +17,8 @@ namespace mqtt {
     void publish(const String& mqtt_topic, const String &data, bool retained);
 
     void send_mqtt(const String& data);
+
+    bool loop();
 }
 
 #endif //NAMF_MQTT_H

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -1,0 +1,22 @@
+//
+// Created by Julian Szulc on 08/08/2020.
+//
+
+#ifndef NAMF_MQTT_H
+#define NAMF_MQTT_H
+
+#include "PubSubClient.h"
+#include "ESP8266WiFi.h"
+
+namespace mqtt {
+    extern PubSubClient client;
+
+    void setup(WiFiClient &);
+    void reconnect(int maxRetries = 3);
+
+    void publish(const String& mqtt_topic, const String &data, bool retained);
+
+    void send_mqtt(const String& data);
+}
+
+#endif //NAMF_MQTT_H

--- a/src/sensors/bme280.cpp
+++ b/src/sensors/bme280.cpp
@@ -59,7 +59,7 @@ String sensorBME280() {
             last_value_BME280_T = t;
             last_value_BME280_H = h;
             last_value_BME280_P = p;
-            s += Value2Json(F("BME280_temperature"), Float2String(last_value_BME280_T), F("C"));
+            s += Value2Json(F("BME280_temperature"), Float2String(last_value_BME280_T), F("°C"));
             s += Value2Json(F("BME280_humidity"), Float2String(last_value_BME280_H), F("%"));
             s += Value2Json(F("BME280_pressure"), Float2String(last_value_BME280_P), F("Pa"));
         }

--- a/src/sensors/bme280.cpp
+++ b/src/sensors/bme280.cpp
@@ -59,9 +59,9 @@ String sensorBME280() {
             last_value_BME280_T = t;
             last_value_BME280_H = h;
             last_value_BME280_P = p;
-            s += Value2Json(F("BME280_temperature"), Float2String(last_value_BME280_T));
-            s += Value2Json(F("BME280_humidity"), Float2String(last_value_BME280_H));
-            s += Value2Json(F("BME280_pressure"), Float2String(last_value_BME280_P));
+            s += Value2Json(F("BME280_temperature"), Float2String(last_value_BME280_T), F("C"));
+            s += Value2Json(F("BME280_humidity"), Float2String(last_value_BME280_H), F("%"));
+            s += Value2Json(F("BME280_pressure"), Float2String(last_value_BME280_P), F("Pa"));
         }
         debug_out("----", DEBUG_MIN_INFO, 1);
     } else {

--- a/src/sensors/dht.cpp
+++ b/src/sensors/dht.cpp
@@ -38,8 +38,8 @@ String sensorDHT() {
             debug_out(String(h) + "%", DEBUG_MIN_INFO, 1);
             last_value_DHT_T = t;
             last_value_DHT_H = h;
-            s += Value2Json(F("temperature"), Float2String(last_value_DHT_T));
-            s += Value2Json(F("humidity"), Float2String(last_value_DHT_H));
+            s += Value2Json(F("temperature"), Float2String(last_value_DHT_T), F("C"));
+            s += Value2Json(F("humidity"), Float2String(last_value_DHT_H), F("%"));
         }
     }
     debug_out("----", DEBUG_MIN_INFO, 1);

--- a/src/sensors/dht.cpp
+++ b/src/sensors/dht.cpp
@@ -38,7 +38,7 @@ String sensorDHT() {
             debug_out(String(h) + "%", DEBUG_MIN_INFO, 1);
             last_value_DHT_T = t;
             last_value_DHT_H = h;
-            s += Value2Json(F("temperature"), Float2String(last_value_DHT_T), F("C"));
+            s += Value2Json(F("temperature"), Float2String(last_value_DHT_T), F("°C"));
             s += Value2Json(F("humidity"), Float2String(last_value_DHT_H), F("%"));
         }
     }

--- a/src/sensors/sds011.h
+++ b/src/sensors/sds011.h
@@ -264,6 +264,7 @@ String sensorSDS() {
         readSingleSDSPacket(&pm10_serial, &pm25_serial);
     }
     if (send_now) {
+
         last_value_SDS_P1 = -1;
         last_value_SDS_P2 = -1;
         if (sds_val_count > 2) {
@@ -277,8 +278,9 @@ String sensorSDS() {
             debug_out("PM10:  " + Float2String(last_value_SDS_P1), DEBUG_MIN_INFO, 1);
             debug_out("PM2.5: " + Float2String(last_value_SDS_P2), DEBUG_MIN_INFO, 1);
             debug_out("----", DEBUG_MIN_INFO, 1);
-            s += Value2Json("SDS_P1", Float2String(last_value_SDS_P1));
-            s += Value2Json("SDS_P2", Float2String(last_value_SDS_P2));
+            s += Value2Json(F("SDS_P1"), Float2String(last_value_SDS_P1), F("µg/m³"));
+            s += Value2Json(F("SDS_P2"), Float2String(last_value_SDS_P2), F("µg/m³"));
+
         }
         sds_pm10_sum = 0;
         sds_pm25_sum = 0;

--- a/src/variables.h
+++ b/src/variables.h
@@ -8,7 +8,7 @@
 #if defined(BOOT_FW)
 #define SOFTWARE_VERSION  "NAMF-2020-boot"
 #else
-#define SOFTWARE_VERSION  "NAMF-2020-34rc3"
+#define SOFTWARE_VERSION  "NAMF-2020-32-MQTT"
 #endif
 #include "defines.h"
 #include "system/scheduler.h"
@@ -75,10 +75,10 @@ namespace cfg {
     extern bool send2lora;
     extern bool send2influx;
     extern bool send2csv;
+    extern bool send2mqtt;
     extern bool auto_update;
     extern bool has_display;
     extern u8_t update_channel;
-    extern bool has_display;
     extern bool has_lcd1602;
     extern bool has_lcd1602_27;
     extern bool has_lcd2004_27;
@@ -105,6 +105,13 @@ namespace cfg {
 
     extern String host_influx;
     extern String url_influx;
+
+    extern String host_mqtt;
+    extern int port_mqtt;
+    extern char client_id_mqtt[24];
+    extern String user_mqtt;
+    extern String pwd_mqtt;
+    extern String sensors_topic_mqtt;
 
     extern unsigned long time_for_wifi_config;
     extern unsigned long sending_intervall_ms;

--- a/src/variables_init.h
+++ b/src/variables_init.h
@@ -43,6 +43,7 @@ namespace cfg {
     bool send2custom = SEND2CUSTOM;
     bool send2lora = SEND2LORA;
     bool send2influx = SEND2INFLUX;
+    bool send2mqtt = SEND2MQTT;
     bool send2csv = SEND2CSV;
     bool auto_update = AUTO_UPDATE;
     bool has_display = HAS_DISPLAY;
@@ -73,6 +74,13 @@ namespace cfg {
     String host_influx = FPSTR(HOST_INFLUX);
     String url_influx = FPSTR(URL_INFLUX);
 
+    String host_mqtt = FPSTR(HOST_MQTT);
+    int port_mqtt = PORT_MQTT;
+    String user_mqtt = FPSTR(USER_MQTT);
+    String pwd_mqtt = FPSTR(PWD_MQTT);
+    char client_id_mqtt[24] = CLIENT_ID_MQTT;
+    String sensors_topic_mqtt = SENSOR_TOPIC_PREFIX_MQTT;
+
     unsigned long time_for_wifi_config = 600000;
     unsigned long sending_intervall_ms = 145000;
 
@@ -80,8 +88,16 @@ namespace cfg {
     void initNonTrivials(const char *id) {
         strcpy(cfg::current_lang, CURRENT_LANG);
         if (fs_ssid[0] == '\0') {
-            strcpy(fs_ssid, "NAM-");
+            strcpy(fs_ssid, INITIAL_NAME_PART);
             strcat(fs_ssid, id);
+        }
+        if (client_id_mqtt[0] == '\0') {
+            strcpy(client_id_mqtt, INITIAL_NAME_PART);
+            strcat(client_id_mqtt, id);
+        }
+
+        if (sensors_topic_mqtt.isEmpty()) {
+            sensors_topic_mqtt = String(F("/")) + client_id_mqtt + F("/sensors/");
         }
     }
 }

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -582,6 +582,7 @@ void webserver_config() {
             parseHTTP(F("user_mqtt"), user_mqtt);
             readPasswdStringParam(pwd_mqtt);
             readCharParam(client_id_mqtt);
+            parseHTTP(F("sensors_topic_mqtt"), sensors_topic_mqtt);
             sensors_topic_mqtt.replace(F(" "), F(""));
             if(!sensors_topic_mqtt.endsWith(FPSTR("/"))) {
                 debug_out(F("Missing ending slash in mqtt topic prefix"), DEBUG_MIN_INFO, true);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -2,6 +2,7 @@
 // Created by viciu on 17.02.2020.
 //
 
+#include "defines.h"
 #include "webserver.h"
 template<typename T, std::size_t N> constexpr std::size_t capacity_null_terminated_char_array(const T(&)[N]) {
     return N - 1;
@@ -443,6 +444,17 @@ void webserver_config() {
                                        capacity_null_terminated_char_array(user_influx));
             page_content += form_password("pwd_influx", FPSTR(INTL_PASSWORD), pwd_influx,
                                           capacity_null_terminated_char_array(pwd_influx));
+            page_content += FPSTR(TABLE_TAG_CLOSE_BR);
+            page_content += form_checkbox("send2mqtt", tmpl(FPSTR(INTL_SEND_TO), F("MQTT")), send2mqtt);
+            page_content += FPSTR(TABLE_TAG_OPEN);
+            page_content += form_input(F("host_mqtt"), FPSTR(INTL_SERVER), host_mqtt, 60);
+            page_content += form_input("port_mqtt", FPSTR(INTL_PORT), String(port_mqtt), max_port_digits);
+            page_content += form_input("user_mqtt", FPSTR(INTL_USER), user_mqtt, 128);
+            page_content += form_password("pwd_mqtt", FPSTR(INTL_PASSWORD), pwd_mqtt, 128);
+            page_content += form_input("client_id_mqtt", FPSTR(INTL_CLIENT_ID), client_id_mqtt,
+                                       capacity_null_terminated_char_array(client_id_mqtt));
+            page_content += form_input("sensors_topic_mqtt", FPSTR(INTL_SENSORS_TOPIC_MQTT), sensors_topic_mqtt, SENSOR_TOPIC_PREFIX_MQTT_SIZE);
+
             page_content += form_submit(FPSTR(INTL_SAVE_AND_RESTART));
             page_content += FPSTR(TABLE_TAG_CLOSE_BR);
             page_content += F("<br/></form>");
@@ -554,6 +566,20 @@ void webserver_config() {
             readCharParam(user_influx);
             readPasswdParam(pwd_influx);
 
+            readBoolParam(send2mqtt)
+            parseHTTP(F("host_mqtt"), host_mqtt);
+            readIntParam(port_mqtt);
+            parseHTTP(F("user_mqtt"), user_mqtt);
+            parseHTTP(F("pwd_mqtt"), pwd_mqtt);
+            readCharParam(client_id_mqtt);
+            sensors_topic_mqtt.replace(F(" "), F(""));
+            if(!sensors_topic_mqtt.endsWith(FPSTR("/"))) {
+                debug_out(F("Missing ending slash in mqtt topic prefix"), DEBUG_MIN_INFO, true);
+                if (sensors_topic_mqtt.length() == SENSOR_TOPIC_PREFIX_MQTT_SIZE) {
+                    sensors_topic_mqtt.remove(SENSOR_TOPIC_PREFIX_MQTT_SIZE-1);
+                }
+                sensors_topic_mqtt += FPSTR("/");
+            }
         }
 
         readBoolParam(auto_update);
@@ -629,6 +655,15 @@ void webserver_config() {
         page_content += line_from_value(FPSTR(INTL_PORT), String(port_influx));
         page_content += line_from_value(FPSTR(INTL_USER), user_influx);
         page_content += line_from_value(FPSTR(INTL_PASSWORD), pwd_influx);
+        page_content += F("<br/><br/>MQTT: ");
+        page_content += String(send2mqtt);
+        page_content += line_from_value(FPSTR(INTL_SERVER), host_mqtt);
+        page_content += line_from_value(FPSTR(INTL_PORT), String(port_mqtt));
+        page_content += line_from_value(FPSTR(INTL_CLIENT_ID), client_id_mqtt);
+        page_content += line_from_value(FPSTR(INTL_USER), user_mqtt);
+        page_content += line_from_value(FPSTR(INTL_PASSWORD), pwd_mqtt);
+        page_content += line_from_value(FPSTR(INTL_SENSORS_TOPIC_MQTT), sensors_topic_mqtt);
+
         page_content += F("<br/><br/>");
         page_content += FPSTR(INTL_SENSOR_IS_REBOOTING);
     }

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -450,7 +450,7 @@ void webserver_config() {
             page_content += form_input(F("host_mqtt"), FPSTR(INTL_SERVER), host_mqtt, 60);
             page_content += form_input("port_mqtt", FPSTR(INTL_PORT), String(port_mqtt), max_port_digits);
             page_content += form_input("user_mqtt", FPSTR(INTL_USER), user_mqtt, 128);
-            page_content += form_password("pwd_mqtt", FPSTR(INTL_PASSWORD), pwd_mqtt, 128);
+            page_content += form_password("pwd_mqtt", FPSTR(INTL_PASSWORD), pwd_mqtt, 256);
             page_content += form_input("client_id_mqtt", FPSTR(INTL_CLIENT_ID), client_id_mqtt,
                                        capacity_null_terminated_char_array(client_id_mqtt));
             page_content += form_input("sensors_topic_mqtt", FPSTR(INTL_SENSORS_TOPIC_MQTT), sensors_topic_mqtt, SENSOR_TOPIC_PREFIX_MQTT_SIZE);
@@ -503,6 +503,16 @@ void webserver_config() {
                 masked_pwd += "*"; \
             if (masked_pwd != server.arg(#param) || server.arg(#param) == "") {\
                 server.arg(#param).toCharArray(param, sizeof(param)); \
+            }\
+        }
+
+#define readPasswdStringParam(param) \
+        if (server.hasArg(#param)){ \
+            masked_pwd = ""; \
+            for (uint8_t i=0;i<server.arg(#param).length();i++) \
+                masked_pwd += "*";   \
+            if (masked_pwd != server.arg(#param) || server.arg(#param) == "") {\
+                param = server.arg(#param); \
             }\
         }
 
@@ -570,7 +580,7 @@ void webserver_config() {
             parseHTTP(F("host_mqtt"), host_mqtt);
             readIntParam(port_mqtt);
             parseHTTP(F("user_mqtt"), user_mqtt);
-            parseHTTP(F("pwd_mqtt"), pwd_mqtt);
+            readPasswdStringParam(pwd_mqtt);
             readCharParam(client_id_mqtt);
             sensors_topic_mqtt.replace(F(" "), F(""));
             if(!sensors_topic_mqtt.endsWith(FPSTR("/"))) {
@@ -614,6 +624,7 @@ void webserver_config() {
 #undef readIntParam
 #undef readTimeParam
 #undef readPasswdParam
+#undef readPasswdStringParam
 
         page_content += line_from_value(tmpl(FPSTR(INTL_SEND_TO), F("Luftdaten.info")), String(send2dusti));
         page_content += line_from_value(tmpl(FPSTR(INTL_SEND_TO), F("Madavi")), String(send2madavi));


### PR DESCRIPTION
This PR adds support for MQTT broker:
Supports
* custom topic prefix
* custom client id
* login and password for broker connection

Each sensor is exported to separate topic.
Example:

```
tele/namf-01/sensors/SDS_P1
{"value":6.87,"unit":"µg/m³","timestamp":"Sat Oct  3 10:24:54 2020"}

tele/namf-01/sensors/BME280_temperature
{"value":24.5,"unit":"°C","timestamp":"Sat Oct  3 10:24:54 2020"}
```

Messages are not retained.
If auth error occures, reconnecting while executing mqtt::loop is postponed for 1024 loops or until sending data is required.
